### PR TITLE
add loader dir to packaged entries list

### DIFF
--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -9,7 +9,8 @@
   "types": "dist/types/components.d.ts",
   "collection": "dist/collection/collection-manifest.json",
   "files": [
-    "dist/"
+    "dist/",
+    "loader"
   ],
   "scripts": {
     "build": "stencil build --docs",


### PR DESCRIPTION
component-library-react is looking for the loader dir, which is built outside of the dist dir (see esmLoaderPath setting in stencil config file). For that directory to be available it needs to be part of the "files" list in package.json